### PR TITLE
chore: add disabeld

### DIFF
--- a/src/components/Containers.tsx
+++ b/src/components/Containers.tsx
@@ -398,6 +398,7 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
                         <IconButton
                           icon={<DeleteIcon />}
                           aria-label="Delete item"
+                          disabled={isReadOnly || disabled || readOnly}
                           onClick={() => remove(i)}
                           {...arrayStyles.deleteButton}
                         />


### PR DESCRIPTION
## Issue
When component `ArrayField` is not draggable, delete icon cannot be disabled 
## Change
add `disabled={isReadOnly || disabled || readOnly}` to match https://github.com/localz/react-hook-form-generator/blob/master/src/components/Containers.tsx#L369