### PR TITLE
feat: extended shouldDisplay for nested array fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.11",
+  "version": "1.0.12",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/Containers.tsx
+++ b/src/components/Containers.tsx
@@ -274,7 +274,7 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
   };
 
   const isVisible = useMemo(() => {
-    return shouldDisplay ? shouldDisplay(values, index) : true;
+    return shouldDisplay ? shouldDisplay(values, index, nestedIndex) : true;
   }, [values, shouldDisplay]);
 
   if (!isVisible) {
@@ -336,50 +336,60 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
                     {...provided.droppableProps}
                     ref={provided.innerRef}
                   >
-                    {fields.map((item, i) => (
-                      <Draggable
-                        key={`${name}[${i}]`}
-                        draggableId={`${name}[${i}]`}
-                        index={i}
-                      >
-                        {(provided) => (
-                          <Box
-                            key={item?.id || `${name}[${i}]`}
-                            {...arrayStyles.itemContainer}
-                            ref={provided.innerRef}
-                            {...provided.draggableProps}
-                            sx={{
-                              ...provided.draggableProps.style,
-                              gridTemplateColumns: '1fr 2.5rem 2rem',
-                            }}
-                          >
-                            {renderField(
-                              [`${name}[${i}]`, itemField],
-                              item.id,
-                              item,
-                              i,
-                              nestedIndex ? [...nestedIndex, i] : [i]
-                            )}
-                            <ButtonGroup {...arrayStyles.buttonGroup}>
-                              <IconButton
-                                icon={<DragHandleIcon />}
-                                aria-label="Drag item"
-                                disabled={isReadOnly || disabled || readOnly}
-                                {...provided.dragHandleProps}
-                                {...arrayStyles.dragButton}
-                              />
-                              <IconButton
-                                icon={<DeleteIcon />}
-                                aria-label="Delete item"
-                                disabled={isReadOnly || disabled || readOnly}
-                                onClick={() => remove(i)}
-                                {...arrayStyles.deleteButton}
-                              />
-                            </ButtonGroup>
-                          </Box>
-                        )}
-                      </Draggable>
-                    ))}
+                    {fields.map((item, i) => {
+                      const { shouldDisplay } = itemField as FieldSchema;
+                      if (
+                        shouldDisplay &&
+                        !shouldDisplay(values, index, nestedIndex)
+                      ) {
+                        return null;
+                      }
+
+                      return (
+                        <Draggable
+                          key={`${name}[${i}]`}
+                          draggableId={`${name}[${i}]`}
+                          index={i}
+                        >
+                          {(provided) => (
+                            <Box
+                              key={item?.id || `${name}[${i}]`}
+                              {...arrayStyles.itemContainer}
+                              ref={provided.innerRef}
+                              {...provided.draggableProps}
+                              sx={{
+                                ...provided.draggableProps.style,
+                                gridTemplateColumns: '1fr 2.5rem 2rem',
+                              }}
+                            >
+                              {renderField(
+                                [`${name}[${i}]`, itemField],
+                                item.id,
+                                item,
+                                i,
+                                nestedIndex ? [...nestedIndex, i] : [i]
+                              )}
+                              <ButtonGroup {...arrayStyles.buttonGroup}>
+                                <IconButton
+                                  icon={<DragHandleIcon />}
+                                  aria-label="Drag item"
+                                  disabled={isReadOnly || disabled || readOnly}
+                                  {...provided.dragHandleProps}
+                                  {...arrayStyles.dragButton}
+                                />
+                                <IconButton
+                                  icon={<DeleteIcon />}
+                                  aria-label="Delete item"
+                                  disabled={isReadOnly || disabled || readOnly}
+                                  onClick={() => remove(i)}
+                                  {...arrayStyles.deleteButton}
+                                />
+                              </ButtonGroup>
+                            </Box>
+                          )}
+                        </Draggable>
+                      );
+                    })}
                     <Box>{provided.placeholder}</Box>
                   </Stack>
                 )}
@@ -388,29 +398,39 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
             {!draggable && (
               <Collapse in={isOpen} style={{ overflow: 'visible' }}>
                 <Stack {...arrayStyles.arrayContainer}>
-                  {fields.map((item, i) => (
-                    <Box
-                      key={item?.id || `${name}[${i}]`}
-                      {...arrayStyles.itemContainer}
-                    >
-                      {renderField(
-                        [`${name}[${i}]`, itemField],
-                        item.id,
-                        item,
-                        i,
-                        nestedIndex ? [...nestedIndex, i] : [i]
-                      )}
-                      <Box {...arrayStyles.deleteItemContainer}>
-                        <IconButton
-                          icon={<DeleteIcon />}
-                          aria-label="Delete item"
-                          disabled={isReadOnly || disabled || readOnly}
-                          onClick={() => remove(i)}
-                          {...arrayStyles.deleteButton}
-                        />
+                  {fields.map((item, i) => {
+                    const { shouldDisplay } = itemField as FieldSchema;
+                    if (
+                      shouldDisplay &&
+                      !shouldDisplay(values, index, nestedIndex)
+                    ) {
+                      return null;
+                    }
+
+                    return (
+                      <Box
+                        key={item?.id || `${name}[${i}]`}
+                        {...arrayStyles.itemContainer}
+                      >
+                        {renderField(
+                          [`${name}[${i}]`, itemField],
+                          item.id,
+                          item,
+                          i,
+                          nestedIndex ? [...nestedIndex, i] : [i]
+                        )}
+                        <Box {...arrayStyles.deleteItemContainer}>
+                          <IconButton
+                            icon={<DeleteIcon />}
+                            aria-label="Delete item"
+                            disabled={isReadOnly || disabled || readOnly}
+                            onClick={() => remove(i)}
+                            {...arrayStyles.deleteButton}
+                          />
+                        </Box>
                       </Box>
-                    </Box>
-                  ))}
+                    );
+                  })}
                 </Stack>
               </Collapse>
             )}
@@ -487,7 +507,7 @@ export const ObjectField: FC<FieldProps<ObjectFieldSchema>> = ({
   const errorMessage = useErrorMessage(name, field.label);
 
   const isVisible = useMemo(() => {
-    return shouldDisplay ? shouldDisplay(values, index) : true;
+    return shouldDisplay ? shouldDisplay(values, index, nestedIndex) : true;
   }, [values, shouldDisplay]);
 
   if (!isVisible) {
@@ -527,7 +547,10 @@ export const ObjectField: FC<FieldProps<ObjectFieldSchema>> = ({
             {Object.entries(field.properties).map(
               ([fieldName, objectField], i) => {
                 const { shouldDisplay } = objectField as FieldSchema;
-                if (shouldDisplay && !shouldDisplay(values, index)) {
+                if (
+                  shouldDisplay &&
+                  !shouldDisplay(values, index, nestedIndex)
+                ) {
                   return null;
                 }
 

--- a/src/components/Containers.tsx
+++ b/src/components/Containers.tsx
@@ -245,6 +245,7 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
     tooltip,
     disabled,
     readOnly,
+    disableButtons,
   } = field;
 
   const { control } = useFormContext();
@@ -306,14 +307,14 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
                 icon={<AddIcon />}
                 aria-label="Add item"
                 onClick={addItem}
-                disabled={isReadOnly || disabled || readOnly}
+                disabled={isReadOnly || disabled || readOnly || disableButtons}
                 {...arrayStyles.addButton}
               />
               <IconButton
                 icon={<DeleteIcon />}
                 aria-label="Clear items"
                 onClick={() => remove()}
-                disabled={isReadOnly || disabled || readOnly}
+                disabled={isReadOnly || disabled || readOnly || disableButtons}
                 {...arrayStyles.clearButton}
               />
               {isCollapsible && (
@@ -321,7 +322,9 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
                   icon={isOpen ? <ViewOffIcon /> : <ViewIcon />}
                   aria-label={isOpen ? 'Hide items' : 'Show items'}
                   onClick={onToggle}
-                  disabled={isReadOnly || disabled || readOnly}
+                  disabled={
+                    isReadOnly || disabled || readOnly || disableButtons
+                  }
                   {...arrayStyles.collapseButton}
                 />
               )}
@@ -373,14 +376,24 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
                                 <IconButton
                                   icon={<DragHandleIcon />}
                                   aria-label="Drag item"
-                                  disabled={isReadOnly || disabled || readOnly}
+                                  disabled={
+                                    isReadOnly ||
+                                    disabled ||
+                                    readOnly ||
+                                    disableButtons
+                                  }
                                   {...provided.dragHandleProps}
                                   {...arrayStyles.dragButton}
                                 />
                                 <IconButton
                                   icon={<DeleteIcon />}
                                   aria-label="Delete item"
-                                  disabled={isReadOnly || disabled || readOnly}
+                                  disabled={
+                                    isReadOnly ||
+                                    disabled ||
+                                    readOnly ||
+                                    disableButtons
+                                  }
                                   onClick={() => remove(i)}
                                   {...arrayStyles.deleteButton}
                                 />
@@ -423,7 +436,12 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
                           <IconButton
                             icon={<DeleteIcon />}
                             aria-label="Delete item"
-                            disabled={isReadOnly || disabled || readOnly}
+                            disabled={
+                              isReadOnly ||
+                              disabled ||
+                              readOnly ||
+                              disableButtons
+                            }
                             onClick={() => remove(i)}
                             {...arrayStyles.deleteButton}
                           />

--- a/src/components/Containers.tsx
+++ b/src/components/Containers.tsx
@@ -59,7 +59,8 @@ export const renderField = (
   [name, field]: [string, Field],
   id?: string,
   defaultValue?: any,
-  index?: any
+  index?: any,
+  nestedIndex?: (number | undefined)[]
 ) => {
   let Component: any = null;
 
@@ -131,6 +132,7 @@ export const renderField = (
             field={field}
             defaultValue={defaultValue}
             index={index}
+            nestedIndex={nestedIndex}
             {...field.props}
           />
         </Fragment>
@@ -149,6 +151,7 @@ export const renderField = (
         field={field}
         defaultValue={defaultValue}
         index={index}
+        nestedIndex={nestedIndex}
       />
     </Fragment>
   );
@@ -225,6 +228,7 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
   name,
   field,
   index,
+  nestedIndex,
 }) => {
   const {
     label,
@@ -353,7 +357,8 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
                               [`${name}[${i}]`, itemField],
                               item.id,
                               item,
-                              i
+                              i,
+                              nestedIndex ? [...nestedIndex, i] : [i]
                             )}
                             <ButtonGroup {...arrayStyles.buttonGroup}>
                               <IconButton
@@ -392,7 +397,8 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
                         [`${name}[${i}]`, itemField],
                         item.id,
                         item,
-                        i
+                        i,
+                        nestedIndex ? [...nestedIndex, i] : [i]
                       )}
                       <Box {...arrayStyles.deleteItemContainer}>
                         <IconButton
@@ -452,6 +458,7 @@ export const ObjectField: FC<FieldProps<ObjectFieldSchema>> = ({
   id,
   defaultValue,
   index,
+  nestedIndex,
 }) => {
   const {
     label,
@@ -530,7 +537,8 @@ export const ObjectField: FC<FieldProps<ObjectFieldSchema>> = ({
                       [`${name}.${fieldName}`, objectField],
                       id,
                       defaultValue?.[fieldName],
-                      index
+                      index,
+                      nestedIndex
                     )}
                   </Box>
                 );

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -28,6 +28,7 @@ export const TextField: FC<FieldProps<TextFieldSchema>> = ({
   name,
   field,
   index,
+  nestedIndex,
 }) => {
   const {
     label,
@@ -84,7 +85,7 @@ export const TextField: FC<FieldProps<TextFieldSchema>> = ({
   }, [debouncedValue]);
 
   const isVisible = useMemo(() => {
-    return shouldDisplay ? shouldDisplay(values, index) : true;
+    return shouldDisplay ? shouldDisplay(values, index, nestedIndex) : true;
   }, [values, shouldDisplay]);
 
   if (!isVisible) {

--- a/src/stories/Sandbox.stories.tsx
+++ b/src/stories/Sandbox.stories.tsx
@@ -57,7 +57,7 @@ Sandbox.args = {
   title: 'Sandbox',
   helperText: 'Some text that explains some stuff',
   handleSubmit: (values) => {
-    alert(JSON.stringify(values, null, 2));
+    alert(JSON.stringify(values['nestedField'], null, 2));
   },
   buttons: {
     submit: {
@@ -195,6 +195,45 @@ Sandbox.args = {
       type: 'heading',
       copyToClipboard: true,
       tooltip: 'You can copy this!',
+    },
+    nestedField: {
+      type: 'array',
+      label: 'Nested arrays',
+      itemField: {
+        type: 'object',
+        label: 'Single array',
+        properties: {
+          singleField: {
+            type: 'array',
+            label: '',
+            itemField: {
+              type: 'object',
+              label: 'Object',
+              properties: {
+                label: {
+                  type: 'select',
+                  label: 'Label',
+                  options: options,
+                },
+                hidden: {
+                  type: 'text',
+                  label: 'Hidden field',
+                  shouldDisplay: (values, _, nestedIndex) => {
+                    const option = get(
+                      values,
+                      `nestedField[${get(nestedIndex, 0)}].singleField[${get(
+                        nestedIndex,
+                        1
+                      )}].label.value`
+                    );
+                    return nestedIndex ? option === 3 : true;
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     },
     color: {
       type: 'color',

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export interface FieldProps<T extends FieldSchema> {
   field: T;
   defaultValue?: any;
   index?: number;
+  nestedIndex?: number[];
 }
 
 export interface FieldSchema {
@@ -82,7 +83,11 @@ export interface FieldSchema {
     | ObjectFieldStyles
     | CheckboxFieldStyles
     | SelectFieldStyles;
-  shouldDisplay?: (values?: any, index?: number | null) => boolean;
+  shouldDisplay?: (
+    values?: any,
+    index?: number | null,
+    nestedIndex?: number[]
+  ) => boolean | undefined;
   disabled?: boolean;
   readOnly?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,7 @@ export interface ArrayFieldSchema
   defaultIsOpen?: boolean;
   hideCount?: boolean;
   draggable?: boolean;
+  disableButtons?: boolean;
   itemField: Field;
 }
 


### PR DESCRIPTION
`const schema = {
    x: [
      {
        y: [
          { a : 1 }
        ]
      },
      {
        y: [
          { a : 2,
            b : 3 },
          { a : 4 },
        ]
      }
    ]
  }`
With the above schema, right now there's no way to use the `shouldDisplay` prop to only display the field for `b` when the field for `a` contains a certain value, as they are contained within a nested array. This can be solved by providing an array of indices describing the exact position of the field in the nested array, eg. the position of `{ a: 2, b: 3 }` in this case would be described by [1, 0].