### PR TITLE
feat: added secret field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.14",
+  "version": "1.0.15",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/CodeField.tsx
+++ b/src/components/CodeField.tsx
@@ -22,7 +22,7 @@ import get from 'lodash.get';
 import { isString } from 'lodash';
 
 import LabelElement from './elements/Label';
-import { FieldProps, FieldStyles, CodeFieldSchema } from '../types';
+import { FieldProps, CodeFieldSchema, FieldStyles } from '../types';
 import { useErrorMessage } from '../hooks/useErrorMessage';
 import { useStyles } from '../hooks/useStyles';
 import { Ctx } from './Ctx';
@@ -141,6 +141,7 @@ export const CodeField: FC<FieldProps<CodeFieldSchema>> = ({
                             .getAction('editor.action.formatDocument')
                             .run()
                         }
+                        {...fieldStyles.button}
                       >
                         {beautifyButtonText}
                       </Button>

--- a/src/components/Containers.tsx
+++ b/src/components/Containers.tsx
@@ -227,6 +227,7 @@ const emptyFields = {
   file: {},
   dragDrop: [],
   heading: '',
+  secret: '',
 };
 
 export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({

--- a/src/components/Containers.tsx
+++ b/src/components/Containers.tsx
@@ -54,6 +54,7 @@ import DateField from './DateField';
 import FileField from './FileField';
 import { DragDropField } from './DragDropField';
 import { HeadingField } from './HeadingField';
+import { SecretField } from './SecretField';
 
 export const renderField = (
   [name, field]: [string, Field],
@@ -119,6 +120,10 @@ export const renderField = (
 
     case 'heading':
       Component = HeadingField;
+      break;
+
+    case 'secret':
+      Component = SecretField;
       break;
 
     case 'custom':

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -28,7 +28,7 @@ import {
   UseFormReturn,
   FieldValues,
 } from 'react-hook-form';
-import merge from 'lodash.merge';
+import { isEmpty, merge, omit } from 'lodash';
 import { FormStyles, Field, Schema, SelectOptions } from '../types';
 import { StyleCtx } from '../hooks/useStyles';
 import { TextField } from './TextField';
@@ -51,6 +51,7 @@ import { ColorField } from './ColorField';
 import FileField from './FileField';
 import { HeadingField } from './HeadingField';
 import { formatSelectInput, formatSelectOutput } from '../utils';
+import { SecretField } from './SecretField';
 
 type CustomButton = {
   render: (values: { [x: string]: any }) => ReactNode;
@@ -174,6 +175,10 @@ const renderField = ([name, field]: [string, Field]) => {
       Component = HeadingField;
       break;
 
+    case 'secret':
+      Component = SecretField;
+      break;
+
     case 'custom':
       Component = field.component;
       return (
@@ -230,11 +235,20 @@ const renderForm = ({
           <Box
             as="form"
             onSubmit={form.handleSubmit((values) => {
+              const toOmit: string[] = [];
+              Object.entries(values).forEach(([key, value]) => {
+                if (schema[key]?.type === 'secret' && isEmpty(value)) {
+                  toOmit.push(key);
+                }
+              });
+
               if (formatSelectResults) {
-                return handleSubmit(formatSelectOutput({ values, schema }));
+                return handleSubmit(
+                  omit(formatSelectOutput({ values, schema }), toOmit)
+                );
               }
 
-              return handleSubmit(values);
+              return handleSubmit(omit(values, toOmit));
             })}
             {...baseStyles.form?.container}
           >

--- a/src/components/SecretField.tsx
+++ b/src/components/SecretField.tsx
@@ -25,6 +25,7 @@ export const SecretField: FC<FieldProps<SecretFieldSchema>> = ({
 }) => {
   const {
     label,
+    isRequired,
     placeholder,
     defaultValue,
     shouldDisplay,
@@ -62,7 +63,11 @@ export const SecretField: FC<FieldProps<SecretFieldSchema>> = ({
 
   return (
     <>
-      <FormControl {...fieldStyles.control} isReadOnly={isReadOnly}>
+      <FormControl
+        {...fieldStyles.control}
+        isRequired={isRequired}
+        isReadOnly={isReadOnly}
+      >
         <LabelElement
           label={label}
           name={name}

--- a/src/components/SecretField.tsx
+++ b/src/components/SecretField.tsx
@@ -14,7 +14,7 @@ import { FieldProps, FieldStyles, SecretFieldSchema } from '../types';
 import { useStyles } from '../hooks/useStyles';
 import LabelElement from './elements/Label';
 import { Ctx } from './Ctx';
-import { LockIcon, UnlockIcon } from '@chakra-ui/icons';
+import { CopyIcon, LockIcon, UnlockIcon } from '@chakra-ui/icons';
 
 export const SecretField: FC<FieldProps<SecretFieldSchema>> = ({
   id,
@@ -35,6 +35,8 @@ export const SecretField: FC<FieldProps<SecretFieldSchema>> = ({
     disabled,
     readOnly,
     clearOriginalValue,
+    copyToClipboard,
+    onCopy,
   } = field;
 
   const { isReadOnly } = useContext(Ctx);
@@ -79,6 +81,22 @@ export const SecretField: FC<FieldProps<SecretFieldSchema>> = ({
             defaultValue={defaultValue}
             {...fieldStyles.input}
           />
+          {copyToClipboard && (
+            <InputRightAddon
+              children={
+                <IconButton
+                  icon={<CopyIcon />}
+                  aria-label="copy-value"
+                  size="xs"
+                  onClick={() => {
+                    navigator.clipboard.writeText(values[name]);
+                    onCopy && onCopy();
+                  }}
+                  {...fieldStyles.button}
+                />
+              }
+            />
+          )}
           <InputRightAddon
             children={
               <IconButton

--- a/src/components/SecretField.tsx
+++ b/src/components/SecretField.tsx
@@ -1,0 +1,107 @@
+import React, { FC, useContext, useMemo, useState } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import {
+  FormControl,
+  InputGroup,
+  Input,
+  InputRightAddon,
+  FormHelperText,
+  Divider,
+  IconButton,
+} from '@chakra-ui/react';
+
+import { FieldProps, FieldStyles, SecretFieldSchema } from '../types';
+import { useStyles } from '../hooks/useStyles';
+import LabelElement from './elements/Label';
+import { Ctx } from './Ctx';
+import { LockIcon, UnlockIcon } from '@chakra-ui/icons';
+
+export const SecretField: FC<FieldProps<SecretFieldSchema>> = ({
+  id,
+  name,
+  field,
+  index,
+  nestedIndex,
+}) => {
+  const {
+    label,
+    placeholder,
+    maskedValue,
+    shouldDisplay,
+    styles = {},
+    tooltip,
+    divideAfter,
+    helperText,
+    disabled,
+    readOnly,
+  } = field;
+
+  const { isReadOnly } = useContext(Ctx);
+
+  const fieldStyles = useStyles<FieldStyles>('textField', styles);
+
+  const { register, control, setValue } = useFormContext();
+
+  const values = useWatch({
+    control,
+  });
+
+  const [show, setShow] = useState(false);
+  const [modified, setModified] = useState(false);
+
+  const isVisible = useMemo(() => {
+    return shouldDisplay ? shouldDisplay(values, index, nestedIndex) : true;
+  }, [values, shouldDisplay]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <>
+      <FormControl {...fieldStyles.control} isReadOnly={isReadOnly}>
+        <LabelElement
+          label={label}
+          name={name}
+          fieldStyles={fieldStyles}
+          tooltip={tooltip}
+        />
+        <InputGroup {...fieldStyles.inputGroup}>
+          <Input
+            data-testid={id}
+            type={show ? 'text' : 'password'}
+            aria-label={name}
+            {...register(name)}
+            placeholder={placeholder}
+            disabled={disabled || !show}
+            readOnly={readOnly || !show}
+            defaultValue={maskedValue || ''}
+            {...fieldStyles.input}
+          />
+          <InputRightAddon
+            children={
+              <IconButton
+                icon={show ? <UnlockIcon /> : <LockIcon />}
+                aria-label="unlock-field"
+                size="xs"
+                onClick={() => {
+                  !show && !modified && setValue(name, '');
+                  !modified && setModified(true);
+                  setShow(!show);
+                }}
+                {...fieldStyles.button}
+              />
+            }
+          />
+        </InputGroup>
+        {Boolean(helperText) && (
+          <FormHelperText {...fieldStyles.helperText}>
+            {helperText}
+          </FormHelperText>
+        )}
+      </FormControl>
+
+      {divideAfter && <Divider mt={2} />}
+    </>
+  );
+};

--- a/src/components/SecretField.tsx
+++ b/src/components/SecretField.tsx
@@ -26,7 +26,7 @@ export const SecretField: FC<FieldProps<SecretFieldSchema>> = ({
   const {
     label,
     placeholder,
-    maskedValue,
+    defaultValue,
     shouldDisplay,
     styles = {},
     tooltip,
@@ -34,6 +34,7 @@ export const SecretField: FC<FieldProps<SecretFieldSchema>> = ({
     helperText,
     disabled,
     readOnly,
+    clearOriginalValue,
   } = field;
 
   const { isReadOnly } = useContext(Ctx);
@@ -74,8 +75,8 @@ export const SecretField: FC<FieldProps<SecretFieldSchema>> = ({
             {...register(name)}
             placeholder={placeholder}
             disabled={disabled || !show}
-            readOnly={readOnly || !show}
-            defaultValue={maskedValue || ''}
+            readOnly={readOnly}
+            defaultValue={defaultValue}
             {...fieldStyles.input}
           />
           <InputRightAddon
@@ -85,8 +86,10 @@ export const SecretField: FC<FieldProps<SecretFieldSchema>> = ({
                 aria-label="unlock-field"
                 size="xs"
                 onClick={() => {
-                  !show && !modified && setValue(name, '');
-                  !modified && setModified(true);
+                  if (clearOriginalValue) {
+                    !show && !modified && setValue(name, '');
+                    !modified && setModified(true);
+                  }
                   setShow(!show);
                 }}
                 {...fieldStyles.button}

--- a/src/stories/Sandbox.stories.tsx
+++ b/src/stories/Sandbox.stories.tsx
@@ -133,6 +133,7 @@ Sandbox.args = {
       type: 'secret',
       label: 'Password',
       clearOriginalValue: true,
+      copyToClipboard: true,
     },
     expectedActions: {
       type: 'dragDrop',

--- a/src/stories/Sandbox.stories.tsx
+++ b/src/stories/Sandbox.stories.tsx
@@ -57,7 +57,7 @@ Sandbox.args = {
   title: 'Sandbox',
   helperText: 'Some text that explains some stuff',
   handleSubmit: (values) => {
-    alert(JSON.stringify(values['nestedField'], null, 2));
+    alert(JSON.stringify(values, null, 2));
   },
   buttons: {
     submit: {
@@ -128,6 +128,11 @@ Sandbox.args = {
   },
 
   schema: {
+    secret: {
+      type: 'secret',
+      label: 'Password',
+      maskedValue: '*****',
+    },
     expectedActions: {
       type: 'dragDrop',
       label: 'Expected actions',

--- a/src/stories/Sandbox.stories.tsx
+++ b/src/stories/Sandbox.stories.tsx
@@ -68,6 +68,7 @@ Sandbox.args = {
   isReadOnly: false,
   formOptions: {
     defaultValues: {
+      secret: 'secretPassword',
       color: '#000000',
       options: [
         {
@@ -131,7 +132,7 @@ Sandbox.args = {
     secret: {
       type: 'secret',
       label: 'Password',
-      maskedValue: '*****',
+      clearOriginalValue: true,
     },
     expectedActions: {
       type: 'dragDrop',

--- a/src/stories/Sandbox.stories.tsx
+++ b/src/stories/Sandbox.stories.tsx
@@ -134,6 +134,7 @@ Sandbox.args = {
       label: 'Password',
       clearOriginalValue: true,
       copyToClipboard: true,
+      isRequired: true,
     },
     expectedActions: {
       type: 'dragDrop',

--- a/src/types.ts
+++ b/src/types.ts
@@ -340,6 +340,7 @@ export interface SecretFieldSchema
       | 'label'
       | 'helperText'
       | 'divideAfter'
+      | 'isRequired'
       | 'placeholder'
       | 'tooltip'
       | 'defaultValue'

--- a/src/types.ts
+++ b/src/types.ts
@@ -345,7 +345,7 @@ export interface SecretFieldSchema
       | 'defaultValue'
     > {
   type: 'secret';
-  maskedValue: string | null;
+  clearOriginalValue?: boolean;
 }
 
 export interface FormStyles {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,8 @@ export type Field =
   | DateFieldSchema
   | ColorFieldSchema
   | FileFieldSchema
-  | HeadingFieldSchema;
+  | HeadingFieldSchema
+  | SecretFieldSchema;
 
 export interface FieldProps<T extends FieldSchema> {
   id?: string;
@@ -76,6 +77,7 @@ export interface FieldSchema {
     | 'color'
     | 'file'
     | 'heading'
+    | 'secret'
     | 'custom';
   styles?:
     | FieldStyles
@@ -330,6 +332,21 @@ export interface SelectFieldSchemaWithOptions
 }
 
 export type SelectFieldSchema = SelectFieldSchemaWithOptions;
+
+export interface SecretFieldSchema
+  extends FieldSchema,
+    Pick<
+      FormController,
+      | 'label'
+      | 'helperText'
+      | 'divideAfter'
+      | 'placeholder'
+      | 'tooltip'
+      | 'defaultValue'
+    > {
+  type: 'secret';
+  maskedValue: string | null;
+}
 
 export interface FormStyles {
   form?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -346,6 +346,8 @@ export interface SecretFieldSchema
     > {
   type: 'secret';
   clearOriginalValue?: boolean;
+  copyToClipboard?: boolean;
+  onCopy?: () => void;
 }
 
 export interface FormStyles {


### PR DESCRIPTION
Added a secret field component, where the value is only shown and submitted when the lock icon is unlocked.
![image](https://user-images.githubusercontent.com/48301819/221743035-f190142d-da32-4082-bd22-72c0a494b3c9.png)
There is a prop to also clear the original masked value, to hide it entirely from the user.