### PR TITLE
Fix/falsy array values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/Containers.tsx
+++ b/src/components/Containers.tsx
@@ -348,7 +348,7 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
                     {...provided.droppableProps}
                     ref={provided.innerRef}
                   >
-                    {fields.map((item, i) => {
+                    {fields?.map((item, i) => {
                       const { shouldDisplay } = itemField as FieldSchema;
                       if (
                         shouldDisplay &&
@@ -420,7 +420,7 @@ export const ArrayField: FC<FieldProps<ArrayFieldSchema>> = ({
             {!draggable && (
               <Collapse in={isOpen} style={{ overflow: 'visible' }}>
                 <Stack {...arrayStyles.arrayContainer}>
-                  {fields.map((item, i) => {
+                  {fields?.map((item, i) => {
                     const { shouldDisplay } = itemField as FieldSchema;
                     if (
                       shouldDisplay &&
@@ -569,7 +569,7 @@ export const ObjectField: FC<FieldProps<ObjectFieldSchema>> = ({
         </Flex>
         <Collapse in={isOpen} style={{ overflow: 'visible' }}>
           <Stack {...objectStyles.objectContainer}>
-            {Object.entries(field.properties).map(
+            {Object.entries(field.properties)?.map(
               ([fieldName, objectField], i) => {
                 const { shouldDisplay } = objectField as FieldSchema;
                 if (

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -327,12 +327,14 @@ const renderForm = ({
 function formatDefaultValues(defaultValues: any, schema: Schema) {
   function replaceFalsyArrays(values: { [x: string]: any }, schema: Schema) {
     if (values && typeof values === 'object') {
+      const toOmit: string[] = [];
+
       Object.entries(values).forEach(([key, value]) => {
         if (schema[key]?.type === 'array') {
           const arrayItemField = (schema[key] as ArrayFieldSchema).itemField;
           if (!value) {
-            // Replace the falsy value with an empty array to prevent errors
-            values[key] = [];
+            // Omit the property with the falsy value
+            toOmit.push(key);
           } else if (arrayItemField.type === 'object') {
             // There may be more undefined arrays nested within this array of objects, recurse further
             values[key] = value.map((currValue: any) =>
@@ -351,6 +353,8 @@ function formatDefaultValues(defaultValues: any, schema: Schema) {
           values[key] = value;
         }
       });
+
+      return omit(values, toOmit);
     }
     return values;
   }

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -28,8 +28,15 @@ import {
   UseFormReturn,
   FieldValues,
 } from 'react-hook-form';
-import { isEmpty, merge, omit } from 'lodash';
-import { FormStyles, Field, Schema, SelectOptions } from '../types';
+import { isEmpty, merge, omit, cloneDeep } from 'lodash';
+import {
+  FormStyles,
+  Field,
+  Schema,
+  SelectOptions,
+  ArrayFieldSchema,
+  ObjectFieldSchema,
+} from '../types';
 import { StyleCtx } from '../hooks/useStyles';
 import { TextField } from './TextField';
 import { TextAreaField } from './TextAreaField';
@@ -316,6 +323,41 @@ const renderForm = ({
   );
 };
 
+function formatDefaultValues(defaultValues: any, schema: Schema) {
+  function replaceFalsyArrays(values: { [x: string]: any }, schema: Schema) {
+    if (values && typeof values === 'object') {
+      Object.entries(values).forEach(([key, value]) => {
+        if (schema[key]?.type === 'array') {
+          const arrayItemField = (schema[key] as ArrayFieldSchema).itemField;
+          if (!value) {
+            // Replace the falsy value with an empty array to prevent errors
+            values[key] = [];
+          } else if (arrayItemField.type === 'object') {
+            // There may be more undefined arrays nested within this array of objects, recurse further
+            values[key] = value.map((currValue: any) =>
+              replaceFalsyArrays(currValue, arrayItemField.properties)
+            );
+          } else {
+            // There are no more nested arrays in this path
+            values[key] = value;
+          }
+        } else if (schema[key]?.type === 'object') {
+          values[key] = replaceFalsyArrays(
+            value,
+            (schema[key] as ObjectFieldSchema).properties
+          );
+        } else {
+          values[key] = value;
+        }
+      });
+    }
+    return values;
+  }
+  const initialClone = cloneDeep(defaultValues);
+  //return cloneDeepWith(initialClone, omitFn);
+  return replaceFalsyArrays(initialClone, schema);
+}
+
 export function Form({
   title,
   helperText,
@@ -336,15 +378,23 @@ export function Form({
       return {};
     }
 
-    if (formOptions.defaultValues && formatSelectDefaultValues) {
-      return {
-        ...formOptions,
-        defaultValues: formatSelectInput({
-          selectOptions: selectOptions || {},
-          defaultValues: formOptions.defaultValues,
-          schema,
-        }),
-      };
+    if (formOptions.defaultValues) {
+      const formattedDefaultValues = formatDefaultValues(
+        formOptions.defaultValues,
+        schema
+      );
+
+      if (formatSelectDefaultValues) {
+        return {
+          ...formOptions,
+          defaultValues: formatSelectInput({
+            selectOptions: selectOptions || {},
+            defaultValues: formattedDefaultValues,
+            schema,
+          }),
+        };
+      }
+      return { ...formOptions, defaultValues: formattedDefaultValues };
     }
 
     return formOptions;


### PR DESCRIPTION
Hey there, formgen user! Has the error below been driving you insane?
![image](https://user-images.githubusercontent.com/48301819/234771173-a1c68e30-8dea-4c6b-a7fc-6fc10455540d.png)
Well, now you can rest easy because this fix will solve everything! 
Basically, the error occurs when null or undefined is passed as a default value for an array property (strange field array behaviour, you'd think it should be able to handle that). By simply omitting the attributes with these falsy values, the error is prevented, and the day is saved.